### PR TITLE
Fix stale cache in data saving

### DIFF
--- a/data.py
+++ b/data.py
@@ -33,6 +33,8 @@ def save_data(df):
     values = df.astype(str).values.tolist()
     for row in values:
         sheet.append_row(row)
+    # Clear cached data so subsequent calls reflect the latest changes
+    load_data.clear()
 
 def add_item(new_item):
     df = load_data()


### PR DESCRIPTION
## Summary
- invalidate cached data after saving to Google Sheets so that newly added or edited items appear immediately

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_683ffc2cbdb083269fdb8752ed88a970